### PR TITLE
Some more tests...

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,7 +9,7 @@ foreach(test ${TESTS})
   set(TARGET_UNIT_TEST_EXE ${executable})
   set(TARGET_RUN_UNIT_TEST run_${executable})
 
-  add_executable(${TARGET_UNIT_TEST_EXE} ${test} verify_buffer.c)
+  add_executable(${TARGET_UNIT_TEST_EXE} ${test})
   target_link_libraries(${TARGET_UNIT_TEST_EXE} bigmpi m ${MPI_LIBRARIES})
 
   set(exclude_list "test_assert_x;test_factorize")

--- a/test/test_bsend_recv_x.c
+++ b/test/test_bsend_recv_x.c
@@ -1,0 +1,78 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <limits.h>
+#include <string.h>
+#include <strings.h>
+
+#include <mpi.h>
+#include "bigmpi.h"
+#include "verify_buffer.h"
+
+#ifdef BIGMPI_MAX_INT
+const MPI_Count test_int_max = BIGMPI_MAX_INT;
+#else
+#include <limits.h>
+const MPI_Count test_int_max = INT_MAX;
+#endif
+
+/* Yes, it is technically unsafe to cast MPI_Count to MPI_Aint or size_t without checking,
+ * given that MPI_Count might be 128b and MPI_Aint and size_t might be 64b, but BigMPI
+ * does not aspire to support communication of more than 8 EiB messages at a time. */
+
+int main(int argc, char * argv[])
+{
+    MPI_Init(&argc, &argv);
+
+    int rank, size;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    if (size<2) {
+        printf("Use 2 or more processes. \n");
+        MPI_Finalize();
+        return 1;
+    }
+
+    int l = (argc > 1) ? atoi(argv[1]) : 2;
+    int m = (argc > 2) ? atoi(argv[2]) : 17777;
+    MPI_Count n = l * test_int_max + m;
+    MPI_Count o = n + MPI_BSEND_OVERHEAD;
+
+    char * buf1 = NULL;
+    char * buf2 = NULL;
+
+    MPI_Alloc_mem((MPI_Aint)n, MPI_INFO_NULL, &buf1);
+    buf2 = malloc(o);
+    MPI_Buffer_attach(buf2, o);
+
+    memset(buf1, rank, (size_t)n);
+
+    size_t errors = 0;
+    for (int r = 1; r < size; r++) {
+
+        /* pairwise communication */
+        if (rank==r) {
+            MPIX_Bsend_x(buf1, n, MPI_CHAR, 0 /* dst */, r /* tag */, MPI_COMM_WORLD);
+        }
+        else if (rank==0) {
+            MPIX_Recv_x(buf1, n, MPI_CHAR, r /* src */, r /* tag */, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+
+            errors += verify_buffer(buf1, n, r);
+            if (errors > 0) {
+                printf("There were %zu errors!", errors);
+            }
+        }
+    }
+
+    MPI_Free_mem(buf1);
+    MPI_Buffer_detach(&buf2, &o);
+    free(buf2);
+
+    if (rank==0 && errors==0) {
+        printf("SUCCESS\n");
+    }
+
+    MPI_Finalize();
+
+    return 0;
+}

--- a/test/test_ibsend_irecv_x.c
+++ b/test/test_ibsend_irecv_x.c
@@ -1,0 +1,88 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <limits.h>
+#include <string.h>
+#include <strings.h>
+
+#include <mpi.h>
+#include "bigmpi.h"
+#include "verify_buffer.h"
+
+#ifdef BIGMPI_MAX_INT
+const MPI_Count test_int_max = BIGMPI_MAX_INT;
+#else
+#include <limits.h>
+const MPI_Count test_int_max = INT_MAX;
+#endif
+
+/* Yes, it is technically unsafe to cast MPI_Count to MPI_Aint or size_t without checking,
+ * given that MPI_Count might be 128b and MPI_Aint and size_t might be 64b, but BigMPI
+ * does not aspire to support communication of more than 8 EiB messages at a time. */
+
+int main(int argc, char * argv[])
+{
+    MPI_Init(&argc, &argv);
+
+    int rank, size;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    if (size<2) {
+        printf("Use 2 or more processes. \n");
+        MPI_Finalize();
+        return 1;
+    }
+
+    int l = (argc > 1) ? atoi(argv[1]) : 2;
+    int m = (argc > 2) ? atoi(argv[2]) : 17777;
+    MPI_Count n = l * test_int_max + m;
+    MPI_Count o = n + MPI_BSEND_OVERHEAD;
+
+    char * buf1 = NULL;
+    char * buf2 = NULL;
+
+    MPI_Alloc_mem((MPI_Aint)n, MPI_INFO_NULL, &buf1);
+    buf2 = malloc(o);
+    MPI_Buffer_attach(buf2, o);
+
+    memset(buf1, rank, (size_t)n);
+
+    size_t errors = 0;
+    for (int r = 1; r < size; r++) {
+
+        MPI_Request req;
+
+        /* pairwise communication */
+        if (rank==r) {
+            printf("pingA\n");
+            MPIX_Ibsend_x(buf1, n, MPI_CHAR, 0 /* dst */, r /* tag */, MPI_COMM_WORLD, &req);
+            printf("pingB\n");
+        }
+        else if (rank==0) {
+            MPIX_Irecv_x(buf1, n, MPI_CHAR, r /* src */, r /* tag */, MPI_COMM_WORLD, &req);
+        }
+
+        if (rank == 0 || rank==r) {
+            MPI_Wait(&req, MPI_STATUS_IGNORE);
+        }
+
+        if (rank==0) {
+            errors += verify_buffer(buf1, n, r);
+            if (errors > 0) {
+                printf("There were %zu errors!", errors);
+            }
+        }
+    }
+
+    MPI_Free_mem(buf1);
+    MPI_Buffer_detach(&buf2, &o);
+    free(buf2);
+
+    if (rank==0 && errors==0) {
+        printf("SUCCESS\n");
+    }
+
+    MPI_Finalize();
+
+    return 0;
+}

--- a/test/test_irsend_irecv_x.c
+++ b/test/test_irsend_irecv_x.c
@@ -1,0 +1,80 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <limits.h>
+#include <string.h>
+#include <strings.h>
+
+#include <mpi.h>
+#include "bigmpi.h"
+#include "verify_buffer.h"
+
+#ifdef BIGMPI_MAX_INT
+const MPI_Count test_int_max = BIGMPI_MAX_INT;
+#else
+#include <limits.h>
+const MPI_Count test_int_max = INT_MAX;
+#endif
+
+/* Yes, it is technically unsafe to cast MPI_Count to MPI_Aint or size_t without checking,
+ * given that MPI_Count might be 128b and MPI_Aint and size_t might be 64b, but BigMPI
+ * does not aspire to support communication of more than 8 EiB messages at a time. */
+
+int main(int argc, char * argv[])
+{
+    MPI_Init(&argc, &argv);
+
+    int rank, size;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    if (size<2) {
+        printf("Use 2 or more processes. \n");
+        MPI_Finalize();
+        return 1;
+    }
+
+    int l = (argc > 1) ? atoi(argv[1]) : 2;
+    int m = (argc > 2) ? atoi(argv[2]) : 17777;
+    MPI_Count n = l * test_int_max + m;
+
+    char * buf = NULL;
+
+    MPI_Alloc_mem((MPI_Aint)n, MPI_INFO_NULL, &buf);
+
+    memset(buf, rank, (size_t)n);
+
+    size_t errors = 0;
+    for (int r = 1; r < size; r++) {
+
+        MPI_Request req;
+
+        /* pairwise communication */
+        if (rank==r) {
+            MPIX_Irsend_x(buf, n, MPI_CHAR, 0 /* dst */, r /* tag */, MPI_COMM_WORLD, &req);
+        }
+        else if (rank==0) {
+            MPIX_Irecv_x(buf, n, MPI_CHAR, r /* src */, r /* tag */, MPI_COMM_WORLD, &req);
+        }
+
+        if (rank == 0 || rank==r) {
+            MPI_Wait(&req, MPI_STATUS_IGNORE);
+        }
+
+        if (rank==0) {
+            errors += verify_buffer(buf, n, r);
+            if (errors > 0) {
+                printf("There were %zu errors!", errors);
+            }
+        }
+    }
+
+    MPI_Free_mem(buf);
+
+    if (rank==0 && errors==0) {
+        printf("SUCCESS\n");
+    }
+
+    MPI_Finalize();
+
+    return 0;
+}

--- a/test/test_issend_irecv_x.c
+++ b/test/test_issend_irecv_x.c
@@ -1,0 +1,80 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <limits.h>
+#include <string.h>
+#include <strings.h>
+
+#include <mpi.h>
+#include "bigmpi.h"
+#include "verify_buffer.h"
+
+#ifdef BIGMPI_MAX_INT
+const MPI_Count test_int_max = BIGMPI_MAX_INT;
+#else
+#include <limits.h>
+const MPI_Count test_int_max = INT_MAX;
+#endif
+
+/* Yes, it is technically unsafe to cast MPI_Count to MPI_Aint or size_t without checking,
+ * given that MPI_Count might be 128b and MPI_Aint and size_t might be 64b, but BigMPI
+ * does not aspire to support communication of more than 8 EiB messages at a time. */
+
+int main(int argc, char * argv[])
+{
+    MPI_Init(&argc, &argv);
+
+    int rank, size;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    if (size<2) {
+        printf("Use 2 or more processes. \n");
+        MPI_Finalize();
+        return 1;
+    }
+
+    int l = (argc > 1) ? atoi(argv[1]) : 2;
+    int m = (argc > 2) ? atoi(argv[2]) : 17777;
+    MPI_Count n = l * test_int_max + m;
+
+    char * buf = NULL;
+
+    MPI_Alloc_mem((MPI_Aint)n, MPI_INFO_NULL, &buf);
+
+    memset(buf, rank, (size_t)n);
+
+    size_t errors = 0;
+    for (int r = 1; r < size; r++) {
+
+        MPI_Request req;
+
+        /* pairwise communication */
+        if (rank==r) {
+            MPIX_Issend_x(buf, n, MPI_CHAR, 0 /* dst */, r /* tag */, MPI_COMM_WORLD, &req);
+        }
+        else if (rank==0) {
+            MPIX_Irecv_x(buf, n, MPI_CHAR, r /* src */, r /* tag */, MPI_COMM_WORLD, &req);
+        }
+
+        if (rank == 0 || rank==r) {
+            MPI_Wait(&req, MPI_STATUS_IGNORE);
+        }
+
+        if (rank==0) {
+            errors += verify_buffer(buf, n, r);
+            if (errors > 0) {
+                printf("There were %zu errors!", errors);
+            }
+        }
+    }
+
+    MPI_Free_mem(buf);
+
+    if (rank==0 && errors==0) {
+        printf("SUCCESS\n");
+    }
+
+    MPI_Finalize();
+
+    return 0;
+}

--- a/test/test_rsend_recv_x.c
+++ b/test/test_rsend_recv_x.c
@@ -1,0 +1,72 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <limits.h>
+#include <string.h>
+#include <strings.h>
+
+#include <mpi.h>
+#include "bigmpi.h"
+#include "verify_buffer.h"
+
+#ifdef BIGMPI_MAX_INT
+const MPI_Count test_int_max = BIGMPI_MAX_INT;
+#else
+#include <limits.h>
+const MPI_Count test_int_max = INT_MAX;
+#endif
+
+/* Yes, it is technically unsafe to cast MPI_Count to MPI_Aint or size_t without checking,
+ * given that MPI_Count might be 128b and MPI_Aint and size_t might be 64b, but BigMPI
+ * does not aspire to support communication of more than 8 EiB messages at a time. */
+
+int main(int argc, char * argv[])
+{
+    MPI_Init(&argc, &argv);
+
+    int rank, size;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    if (size<2) {
+        printf("Use 2 or more processes. \n");
+        MPI_Finalize();
+        return 1;
+    }
+
+    int l = (argc > 1) ? atoi(argv[1]) : 2;
+    int m = (argc > 2) ? atoi(argv[2]) : 17777;
+    MPI_Count n = l * test_int_max + m;
+
+    char * buf = NULL;
+
+    MPI_Alloc_mem((MPI_Aint)n, MPI_INFO_NULL, &buf);
+
+    memset(buf, rank, (size_t)n);
+
+    size_t errors = 0;
+    for (int r = 1; r < size; r++) {
+
+        /* pairwise communication */
+        if (rank==r) {
+            MPIX_Rsend_x(buf, n, MPI_CHAR, 0 /* dst */, r /* tag */, MPI_COMM_WORLD);
+        }
+        else if (rank==0) {
+            MPIX_Recv_x(buf, n, MPI_CHAR, r /* src */, r /* tag */, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+
+            errors += verify_buffer(buf, n, r);
+            if (errors > 0) {
+                printf("There were %zu errors!", errors);
+            }
+        }
+    }
+
+    MPI_Free_mem(buf);
+
+    if (rank==0 && errors==0) {
+        printf("SUCCESS\n");
+    }
+
+    MPI_Finalize();
+
+    return 0;
+}

--- a/test/test_ssend_recv_x.c
+++ b/test/test_ssend_recv_x.c
@@ -1,0 +1,72 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <limits.h>
+#include <string.h>
+#include <strings.h>
+
+#include <mpi.h>
+#include "bigmpi.h"
+#include "verify_buffer.h"
+
+#ifdef BIGMPI_MAX_INT
+const MPI_Count test_int_max = BIGMPI_MAX_INT;
+#else
+#include <limits.h>
+const MPI_Count test_int_max = INT_MAX;
+#endif
+
+/* Yes, it is technically unsafe to cast MPI_Count to MPI_Aint or size_t without checking,
+ * given that MPI_Count might be 128b and MPI_Aint and size_t might be 64b, but BigMPI
+ * does not aspire to support communication of more than 8 EiB messages at a time. */
+
+int main(int argc, char * argv[])
+{
+    MPI_Init(&argc, &argv);
+
+    int rank, size;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    if (size<2) {
+        printf("Use 2 or more processes. \n");
+        MPI_Finalize();
+        return 1;
+    }
+
+    int l = (argc > 1) ? atoi(argv[1]) : 2;
+    int m = (argc > 2) ? atoi(argv[2]) : 17777;
+    MPI_Count n = l * test_int_max + m;
+
+    char * buf = NULL;
+
+    MPI_Alloc_mem((MPI_Aint)n, MPI_INFO_NULL, &buf);
+
+    memset(buf, rank, (size_t)n);
+
+    size_t errors = 0;
+    for (int r = 1; r < size; r++) {
+
+        /* pairwise communication */
+        if (rank==r) {
+            MPIX_Ssend_x(buf, n, MPI_CHAR, 0 /* dst */, r /* tag */, MPI_COMM_WORLD);
+        }
+        else if (rank==0) {
+            MPIX_Recv_x(buf, n, MPI_CHAR, r /* src */, r /* tag */, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+
+            errors += verify_buffer(buf, n, r);
+            if (errors > 0) {
+                printf("There were %zu errors!", errors);
+            }
+        }
+    }
+
+    MPI_Free_mem(buf);
+
+    if (rank==0 && errors==0) {
+        printf("SUCCESS\n");
+    }
+
+    MPI_Finalize();
+
+    return 0;
+}


### PR DESCRIPTION
...and one question: AFAIK MPI_Buffer_attach() only allows 2GB of buffer size. Does this limit data volumes for MPIX_Bsend_x() and friends? Is MPI_Bsend() widely used anyway?
