### PR TITLE
test: fix various index type

### DIFF
--- a/test/test_allgather_x.c
+++ b/test/test_allgather_x.c
@@ -41,7 +41,7 @@ int main(int argc, char * argv[])
     MPI_Alloc_mem((MPI_Aint)n * size, MPI_INFO_NULL, &buf_recv);
     assert(buf_recv!=NULL);
 
-    for (int j = 0; j < n; ++j) {
+    for (MPI_Count j = 0; j < n; ++j) {
         buf_send[j] = (unsigned char)rank;
     }
     memset(buf_recv, -1, (size_t)n);

--- a/test/test_alltoall_x.c
+++ b/test/test_alltoall_x.c
@@ -42,7 +42,7 @@ int main(int argc, char * argv[])
     assert(buf_recv!=NULL);
 
     for (int i = 0; i < size; ++i) {
-        for (int j = 0; j < n; ++j) {
+        for (MPI_Count j = 0; j < n; ++j) {
             buf_send[i*n+j] = (unsigned char)i;
         }
     }

--- a/test/test_scatter_x.c
+++ b/test/test_scatter_x.c
@@ -43,7 +43,7 @@ int main(int argc, char * argv[])
 
     if (rank==0) {
         for (int i = 0; i < size; ++i) {
-            for (int j = 0; j < n; ++j) {
+            for (MPI_Count j = 0; j < n; ++j) {
                 buf_send[i*n+j] = (unsigned char)i;
             }
         }


### PR DESCRIPTION
mpirun -np 2 test/test_allgather_x 1
used to hang on CentOS 7.1 (gcc 4.8.3) when initializing buf_send