### PR TITLE
Some propositions to improve the CMake compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,17 @@
+if(DEFINED PROJECT_NAME)
+  set(BigMPI_SUBPROJECT ON)
+endif()
+
+project(BigMPI)
+
 cmake_minimum_required(VERSION 2.6.4 FATAL_ERROR)
 
 set(PACKAGE_NAME BigMPI)
+
+# set macosx_rpath
+set(CMAKE_MACOSX_RPATH 1)
+
+# find and use detected mpi
 find_package(MPI)
 
 # generic function to add user-configurable options.
@@ -28,13 +39,15 @@ endif()
 
 add_definitions(-DBIGMPI_VCOLLS_${BIGMPI_VCOLLS})
 
-set(CMAKE_C_FLAGS "-std=c99")
+set_property(GLOBAL PROPERTY C_STANDARD 99)
 
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include")
-add_definitions(${MPI_COMPILE_FLAGS})
 include_directories(${MPI_INCLUDE_PATH})
 
-add_custom_target(test echo "Tests passed.")
+string(APPEND CMAKE_C_COMPILE_FLAGS "${MPI_COMPILE_FLAGS}")
+string(APPEND CMAKE_EXE_LINKER_FLAGS "${MPI_LINK_FLAGS}")
+
+add_custom_target(bigmpi_test echo "Tests passed.")
 
 add_subdirectory(src)
 add_subdirectory(test)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,3 +6,23 @@ add_custom_command(
 
 file(GLOB SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.c")
 add_library(bigmpi ${LIB_LINKAGE_TYPE} ${SOURCES} "bigmpiconf.h")
+
+target_link_libraries ( bigmpi ${MPI_LIBRARIES} )
+
+set_target_properties ( bigmpi PROPERTIES PUBLIC_HEADER "bigmpi.h")
+
+if (NOT CMAKE_INSTALL_LIBDIR)
+  set(CMAKE_INSTALL_LIBDIR lib)
+endif()
+
+if (NOT CMAKE_INSTALL_INCLUDEDIR)
+  set(CMAKE_INSTALL_INCLUDEDIR include)
+endif()
+
+install(TARGETS bigmpi
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    COMPONENT lib
+    )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,8 +2,8 @@ file(GLOB TESTS "test_*.c")
 
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/../src")
 
-foreach(bigmpi_test ${TESTS})
-  string(REPLACE ".c" "" buffer0 ${bigmpi_test})
+foreach(test ${TESTS})
+  string(REPLACE ".c" "" buffer0 ${test})
   string(REPLACE "${CMAKE_SOURCE_DIR}" "" buffer1 ${buffer0})
   string(REPLACE "/" _ buffer2 ${buffer1})
   string(REGEX REPLACE "_test_(.+)" "\\1" executable ${buffer2})
@@ -11,7 +11,7 @@ foreach(bigmpi_test ${TESTS})
   set(TARGET_UNIT_TEST_EXE ${executable})
   set(TARGET_RUN_UNIT_TEST run_${executable})
 
-  add_executable(${TARGET_UNIT_TEST_EXE} ${bigmpi_test})
+  add_executable(${TARGET_UNIT_TEST_EXE} ${test})
   target_link_libraries(${TARGET_UNIT_TEST_EXE} bigmpi m ${MPI_LIBRARIES})
 
   set(exclude_list "test_assert_x;test_factorize")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,8 +2,8 @@ file(GLOB TESTS "test_*.c")
 
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/../src")
 
-foreach(test ${TESTS})
-  string(REPLACE ".c" "" buffer0 ${test})
+foreach(bigmpi_test ${TESTS})
+  string(REPLACE ".c" "" buffer0 ${bigmpi_test})
   string(REPLACE "${CMAKE_SOURCE_DIR}" "" buffer1 ${buffer0})
   string(REPLACE "/" _ buffer2 ${buffer1})
   string(REGEX REPLACE "_test_(.+)" "\\1" executable ${buffer2})
@@ -11,7 +11,7 @@ foreach(test ${TESTS})
   set(TARGET_UNIT_TEST_EXE ${executable})
   set(TARGET_RUN_UNIT_TEST run_${executable})
 
-  add_executable(${TARGET_UNIT_TEST_EXE} ${test})
+  add_executable(${TARGET_UNIT_TEST_EXE} ${bigmpi_test})
   target_link_libraries(${TARGET_UNIT_TEST_EXE} bigmpi m ${MPI_LIBRARIES})
 
   set(exclude_list "test_assert_x;test_factorize")
@@ -20,7 +20,7 @@ foreach(test ${TESTS})
   if(found EQUAL -1)
     add_custom_target(${TARGET_RUN_UNIT_TEST} echo "running ${TARGET_UNIT_TEST_EXE}" && bash -c "${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 2 ./${TARGET_UNIT_TEST_EXE}")
 
-    add_dependencies(test ${TARGET_RUN_UNIT_TEST})
+    add_dependencies(bigmpi_test ${TARGET_RUN_UNIT_TEST})
     add_dependencies(${TARGET_RUN_UNIT_TEST} ${TARGET_UNIT_TEST_EXE})
   endif()
 endforeach()


### PR DESCRIPTION
Hello,

I am interested to use the BigMPI wrappers in one of my project. For this, I want to import BigMPI as a CMake external project and I have made some modifications in my fork that you may be interested to merge.
I have added/modified: 
 - The library installation (you can set the `CMAKE_INSTALL_PREFIX` variable to modify the default location);
  - the setting of the `MACOSX_RPATH` variable;
  - the project definition (and the setting of BigMPI as subproject if needed);
  - the using of the `set_property` functionnality to set the `-std=c99` flag in a more portable way;
  - the linking with mpi library (I think that it avoids the needed to set `CMAKE_C_COMPILER` to `mpicc` but I am not sure);
  - the renaming of the 'test' target as the 'bigmpi_test' one to avoid cmake complains (so tests are lauching by the `make bigmpi_test` command): the test target is already used by CMake for tests created with the `CTest` command.

I have tried to stay close to your previous CMakeLists files so I hope that it will suit you.

Regards,

Algiane